### PR TITLE
Added 'requirejs' property to POM as required by the latest webjars-locator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
         <upstream.version>1.12.0</upstream.version>
         <upstream.url>https://github.com/medialize/URI.js/archive/</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
+        <requirejs>
+            {
+                "paths": {
+                    "URI.js": "URI.js"
+                }
+            }
+        </requirejs>
     </properties>
 
     <build>


### PR DESCRIPTION
The latest _webjars-locator_ library seems to look in every `pom.xml` for this property, and mangles the second part to point to the actual location of URI.js.

For example, it should produce a config like this (after mangling):

```
{"paths":{"URI.js":["/webjars/URI.js/1.12.0/URI.js","URI.js"]}
```

Before this change, _webjars-locator_ simply skipped over this module (no config was generated).
